### PR TITLE
Specify Minimal Mistakes remote theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,9 @@ title: "Dr. Pavel Koprov"
 email: "koprovp@gmail.com"
 description: >- 
   Senior R&D Engineer | Robotics | Digital Twins | Industrial AI
-baseurl: "" 
+baseurl: ""
 url: "https://pkoprov.github.io"
+remote_theme: "mmistakes/minimal-mistakes"
 
 author:
   name: "Pavel Koprov"


### PR DESCRIPTION
## Summary
- configure site to use the Minimal Mistakes remote theme

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `jekyll build` *(fails: `bash: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_688ef7d167f08329acecfad88bb30d6c