### PR TITLE
Add pages collection to Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,11 @@ author:
     - label: "CV"
       url: "/cv/"
 
+collections:
+  pages:
+    output: true
+    permalink: /:path/
+
 header_pages:
   - about.md
   - cv.md


### PR DESCRIPTION
## Summary
- configure Jekyll to output the `pages` collection with clean permalinks

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688ef7de62988329a95b6a8c6a906ca8